### PR TITLE
Remove appcompactv7 dependency

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -24,7 +24,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:21.0.3'
 }
 
 def siteUrl = 'https://github.com/lzyzsd/AndroidRandomColor'      // 项目的主页


### PR DESCRIPTION
This PR removes the transitive dependency of the appcompact-v7. I think this dependency it is not required and should be removed to reduce the amount of code in the final APK and to do not produce compatibility issues if someone need to use a different version of the app compact.